### PR TITLE
Fix sanity check for APPVM_SHOTS_DIR

### DIFF
--- a/qvm-screenshot-tool.sh
+++ b/qvm-screenshot-tool.sh
@@ -374,7 +374,7 @@ if [ X"$appvm" != X"" ]; then
 
    echo "[-] start AppVM: $appvm"
    destdir=$(qvm-run -a --pass-io $appvm "xdg-user-dir PICTURES")
-   if [[ "$destdir" =~ ^/home/user* ]]; then
+   if ! [[ "$destdir" =~ ^/home/user* ]]; then
     APPVM_SHOTS_DIR=$destdir
    fi
 


### PR DESCRIPTION
Currently an `APPVM_SHOTS_DIR` of _/home/user/Pictures/Screenshots_ would be reset to the default Pictures dir, which is not correct in my interpretation.